### PR TITLE
Fix logger passing

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -150,10 +150,11 @@ module.exports = function (helper, factory, exampleTaskName) {
                 ) {
                     var projectConfig = helper._projectConfig,
                         exampleTask = projectConfig && projectConfig._tasks[exampleTaskName],
-                        logger = exampleTask && exampleTask._logger,
-                        magicConfig = new MagicConfig(options.exampleSets);
+                        magicConfig = new MagicConfig(options.exampleSets),
+                        logger;
 
                     exampleTask._makePlatform || (exampleTask.setMakePlatform(helper._taskConfig._makePlatform));
+                    logger = exampleTask && exampleTask._logger;
 
                     return vow.all(exampleHelper._prebuilds.map(function (callback) {
                         return callback.apply(exampleHelper, [magicConfig, logger]);


### PR DESCRIPTION
Столкнулся с проблемой `TypeError: Cannot call method 'logWarningAction' of null`, когда собирал документацию с инлайновыми примерами.

Решается переносом одной строчки.
Я так понимаю, что `_logger` появляется после выполнения `setMakePlatform()`, когда `_makePlatform` отсутствует?