### PR TITLE
jsd: it has information on the inheritance BEM entities

### DIFF
--- a/lib/techs/jsdoc-json.js
+++ b/lib/techs/jsdoc-json.js
@@ -1,6 +1,7 @@
 var vow = require('vow'),
     vfs = require('enb/lib/fs/async-fs'),
-    bemjsd = require('bem-jsd');
+    bemjsd = require('bem-jsd'),
+    naming = require('bem-naming');
 
 module.exports = require('enb/lib/build-flow').create()
     .name('jsdoc-json')
@@ -11,22 +12,35 @@ module.exports = require('enb/lib/build-flow').create()
             target = this._target;
 
         return vow.all(files.map(function (file) {
-                return vfs.read(file.fullname, 'utf8');
+                var basename = file.name.split('.')[0],
+                    entity = naming.parse(basename);
+
+                return vfs.read(file.fullname, 'utf8')
+                    .then(function (src) {
+                        var data = {};
+
+                        if (src.length) {
+                            // 'jsd' which is used by 'bem-jsd' does not handle Windows OS linebreaks
+                            data = bemjsd(src.replace(/\r/g, ''));
+
+                            // 'bemjsd' returns { jsdocType: 'root' } for files without JSDoc
+                            if (Object.keys(data).length < 2) {
+                                data = {};
+                            }
+                        }
+
+                        return {
+                            entity: entity,
+                            data: data
+                        };
+                    });
             }))
-            .then(function (sources) {
-                if (!sources.length) {
-                    return '{}';
-                }
+            .then(function (parts) {
+                var sortedParts = parts.sort(function (part1, part2) {
+                    return Object.keys(part1.entity).length - Object.keys(part2.entity).length;
+                });
 
-                // 'jsd' which is used by 'bemjsd' does not handle Windows OS linebreaks
-                var json = bemjsd(sources.join('\n').replace(/\r/g, ''));
-
-                // 'bemjsd' returns { jsdocType: 'root' } for files without JSDoc
-                if (Object.keys(json).length < 2) {
-                    return '{}';
-                }
-
-                return JSON.stringify(json);
+                return JSON.stringify(sortedParts);
             })
             .fail(function (e) {
                 logger.logWarningAction('js-doc', target, e.stack);


### PR DESCRIPTION
Resolved #41 

* The `bem-jsd` handles each file of BEM entity separately
* The result is an array of information about BEM entity
* Each element of the array consists of `entity` and `data` filed
* The `entity` filed contains information about BEM entities in `bem-naming` format
* The `data` filed contains information about jsdoc