### PR TITLE
Do not generate JSDoc when there's no js file

### DIFF
--- a/lib/techs/jsdoc-json.js
+++ b/lib/techs/jsdoc-json.js
@@ -21,6 +21,11 @@ module.exports = require('enb/lib/build-flow').create()
                 // 'jsd' which is used by 'bemjsd' does not handle Windows OS linebreaks
                 var json = bemjsd(sources.join('\n').replace(/\r/g, ''));
 
+                // 'bemjsd' returns { jsdocType: 'root' } for files without JSDoc
+                if (Object.keys(json).length < 2) {
+                    return '{}';
+                }
+
                 return JSON.stringify(json);
             })
             .fail(function (e) {

--- a/lib/techs/jsdoc-json.js
+++ b/lib/techs/jsdoc-json.js
@@ -14,6 +14,10 @@ module.exports = require('enb/lib/build-flow').create()
                 return vfs.read(file.fullname, 'utf8');
             }))
             .then(function (sources) {
+                if (!sources.length) {
+                    return '{}';
+                }
+
                 // 'jsd' which is used by 'bemjsd' does not handle Windows OS linebreaks
                 var json = bemjsd(sources.join('\n').replace(/\r/g, ''));
 


### PR DESCRIPTION
Now when `sources` is an empty array `enb-bem-docs` will call `join('\n')` and pass this string to `bem-jsd` which will generate following object `{"jsdocType":"root"}`. As a result there's an extra tab on bem.info: https://bem.info/libs/bem-components/v2.1.1/desktop/icon/jsdoc/

This patch fixes the issue.