### PR TITLE
Add entityDeps field to meta.json

### DIFF
--- a/lib/techs/meta-json.js
+++ b/lib/techs/meta-json.js
@@ -1,4 +1,8 @@
-var path = require('path');
+var path = require('path'),
+    vow = require('vow'),
+    vfs = require('enb/lib/fs/async-fs'),
+    vm = require('vm'),
+    bemjsonToDeps = require('bemjson-to-deps');
 
 module.exports = require('enb/lib/build-flow').create()
     .name('meta-json')
@@ -8,6 +12,7 @@ module.exports = require('enb/lib/build-flow').create()
     .builder(function () {
         var node = this.node,
             dir = node.getDir(),
+            logger = node.getLogger(),
             langs = this._langs,
             name = path.basename(dir),
             json = {
@@ -60,6 +65,37 @@ module.exports = require('enb/lib/build-flow').create()
             json.dochtmlFiles = dochtmlFiles;
         }
 
-        return JSON.stringify(json);
+        // Добавляем entityDeps
+        return vow.all(json.examples.map(function (example) {
+            var source = example.source;
+
+            function addEntityDeps (source) {
+                var bemjson;
+
+                try {
+                    bemjson = vm.runInNewContext('(' + source + ')');
+                } catch (err) {
+                    logger.logWarningAction('example', example.path, err.name + ': ' + (err.stack || err.message));
+
+                    return;
+                }
+
+                example.entityDeps = bemjsonToDeps.denormalizeDeps(bemjsonToDeps.getEntities(bemjson));
+
+                return example;
+            }
+
+            if (source) {
+                return addEntityDeps(source);
+            }
+
+            var bemjsonFile = path.join(example.path, example.name + '.bemjson.js.symlink');
+
+            return vfs.read(bemjsonFile, 'utf8').then(addEntityDeps);
+        })).then(function (examples) {
+            json.examples = examples;
+
+            return JSON.stringify(json);
+        });
     })
     .createTech();

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "enb-magic-factory": ">= 0.3.0 < 1.0.0"
   },
   "dependencies": {
-    "bem-md-renderer": "0.2.0",
     "bem-jsd": "1.6.0",
+    "bem-md-renderer": "0.2.0",
     "bem-naming": "0.5.1",
+    "bemjson-to-deps": "1.0.0",
     "enb-bem-pseudo-levels": "0.2.6",
     "enb-bem-techs": "1.0.4",
     "inherit": "2.2.2",
@@ -30,8 +31,8 @@
     "jsdoc-bem": "0.2.1",
     "jsdtmd": "0.0.9",
     "marked": "0.3.3",
-    "toc-md": "0.1.0",
     "shmakowiki": "0.4.0",
+    "toc-md": "0.1.0",
     "vow": "0.4.10",
     "vow-node": "0.3.0"
   },


### PR DESCRIPTION
Collect dependencies for each example to show them in documentation.

Input: content of example BEMJSON.
Output: new field `entityDeps `  in `meta.json` with all entities from input in format of block deps.js.